### PR TITLE
fix: viewer is not using exts prop (ref #16)

### DIFF
--- a/src/Viewer.vue
+++ b/src/Viewer.vue
@@ -41,6 +41,7 @@ export default {
 
     this.editor = Editor.factory({
       el: this.$refs.tuiEditorViewer,
+      exts: this.exts,
       events: eventOption,
       initialValue: this.value,
       height: this.height,

--- a/stories/editor.stories.js
+++ b/stories/editor.stories.js
@@ -1,5 +1,4 @@
 
-import Vue from 'vue';
 import {storiesOf} from '@storybook/vue';
 import {withKnobs} from '@storybook/addon-knobs';
 import {action} from '@storybook/addon-actions';

--- a/stories/viewer.stories.js
+++ b/stories/viewer.stories.js
@@ -1,5 +1,4 @@
 
-import Vue from 'vue';
 import {storiesOf} from '@storybook/vue';
 import {html} from 'common-tags';
 import * as dummy from './dummyData';

--- a/stories/viewer.stories.js
+++ b/stories/viewer.stories.js
@@ -9,7 +9,6 @@ import 'highlight.js/styles/github.css';
 import 'tui-editor/dist/tui-editor.min.css';
 import 'tui-editor/dist/tui-editor-contents.min.css';
 
-import 'tui-editor/dist/tui-editor-extScrollSync';
 import 'tui-editor/dist/tui-editor-extColorSyntax';
 import 'tui-editor/dist/tui-editor-extUML';
 import 'tui-editor/dist/tui-editor-extChart';
@@ -35,7 +34,6 @@ stories.add('demo', () => ({
           minHeight: 100,
           maxHeight: 300
         },
-        'scrollSync',
         'colorSyntax',
         'uml',
         'mark',
@@ -65,7 +63,6 @@ stories.add('change value prop', () => ({
           minHeight: 100,
           maxHeight: 300
         },
-        'scrollSync',
         'colorSyntax',
         'uml',
         'mark',
@@ -100,7 +97,6 @@ stories.add('invoke method', () => ({
           minHeight: 100,
           maxHeight: 300
         },
-        'scrollSync',
         'colorSyntax',
         'uml',
         'mark',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
Although PR #17 has added `exts` property in `Viewer`, it is not used anywhere.

Despite of it, examples of viewer storybook are working because its `Editor` has initialized extensions at editor storybook. Extensions of viewer is not configured by viewer storybook itself. If you try viewer storybook without editor storybook, extensions are not working.

So this PR fix `Viewer` to use its exts property.

Also, scrollSync extension in viewer storybook is causing error.
```
Cannot read property 'get' of undefined
TypeError: Cannot read property 'get' of undefined
    at scrollSyncExtension (http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:188532:18)
    at http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:151695:15
    at Array.forEach (<anonymous>)
    at ExtManager.applyExtension (http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:151686:17)
    at new ToastUIEditorViewer (http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:154061:26)
    at Function.factory (http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:159353:21)
    at VueComponent.mounted (http://localhost:6006/main.1574541a3aa60a44d3a5.hot-update.js:64:69)
    at invokeWithErrorHandling (http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:196508:57)
    at callHook (http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:198825:7)
    at Object.insert (http://localhost:6006/vendors~main.566b849c84711d1f2149.bundle.js:197773:7)
```
Because viewer does not need scrollSync extension, this PR removes it from viewer storybook.

In addition, as minor change, this PR removes unused import from storybooks.